### PR TITLE
fix: Function.name failing IE tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,34 @@ function compatibleMessage(thrown, errMatcher) {
 }
 
 /**
+ * ### .getFunctionName(constructorFn)
+ *
+ * Returns the name of a function.
+ * This also includes a polyfill function if `constructorFn.name` is not defined.
+ *
+ * @name getFunctionName
+ * @param {Function} constructorFn
+ * @namespace Utils
+ * @api private
+ */
+
+var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\(\/]+)/;
+function getFunctionName(constructorFn) {
+  var name = '';
+  if (typeof constructorFn.name === 'undefined') {
+    // Here we run a polyfill if constructorFn.name is not defined
+    var match = String(constructorFn).match(functionNameMatch);
+    if (match) {
+      name = match[1];
+    }
+  } else {
+    name = constructorFn.name;
+  }
+
+  return name;
+}
+
+/**
  * ### .getConstructorName(errorLike)
  *
  * Gets the constructor name for an Error instance or constructor itself.
@@ -99,10 +127,10 @@ function compatibleMessage(thrown, errMatcher) {
 function getConstructorName(errorLike) {
   var constructorName = errorLike;
   if (errorLike instanceof Error) {
-    constructorName = errorLike.constructor.name;
+    constructorName = getFunctionName(errorLike.constructor);
   } else if (typeof errorLike === 'function') {
     // if `err` is not an instance of Error it is an error constructor itself
-    constructorName = new errorLike().name; // eslint-disable-line new-cap
+    constructorName = getFunctionName(errorLike);
   }
 
   return constructorName;

--- a/test/index.js
+++ b/test/index.js
@@ -75,6 +75,18 @@ describe('checkError', function () {
 
     assert(checkError.getConstructorName(null) === null);
     assert(checkError.getConstructorName(undefined) === undefined);
+
+    // Asserting that `getFunctionName` behaves correctly
+    function /*one*/correctName/*two*/() { // eslint-disable-line no-inline-comments, spaced-comment
+      return 0;
+    }
+
+    function withoutComments() {
+      return 1;
+    }
+
+    assert(checkError.getConstructorName(correctName) === 'correctName');
+    assert(checkError.getConstructorName(withoutComments) === 'withoutComments');
   });
 
   it('getMessage', function () {


### PR DESCRIPTION
Here is the fix for #3.

The reason why the build was failing on IE was because of `Function.name` which wasn't supported.
Now instead of getting a function's name using it's `name` I call a function called `getFunctionName` which runs a polyfill (which I've found [here](https://github.com/JamesMGreene/Function.name) and made some minor adaptations) if `.name` is not defined for that function, otherwise we just get it's name through the `.name` property.

This should be enough to work on every single browser.

I also noticed that SauceLabs tests aren't running for PRs. I'll take a look at it further this week too.

PS.: I couldn't add any tests for this since deleting the name property of a function or assigning `undefined` to it makes it `''` instead of `undefined` in order to run the polyfill. However, coverage will be 100% if we consider this branch runs on IE only. However, I'm open to suggestions if you can think of anything else for this.