### PR TITLE
fix: getConstructor name working with PoorlyConstructedErrors

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,8 +129,10 @@ function getConstructorName(errorLike) {
   if (errorLike instanceof Error) {
     constructorName = getFunctionName(errorLike.constructor);
   } else if (typeof errorLike === 'function') {
-    // if `err` is not an instance of Error it is an error constructor itself
-    constructorName = getFunctionName(errorLike);
+    // If `err` is not an instance of Error it is an error constructor itself or another function.
+    // If we've got a common function we get its name, otherwise we may need to create a new instance
+    // of the error just in case it's a poorly-constructed error. Please see chaijs/chai/issues/45 to know more.
+    constructorName = getFunctionName(errorLike) || getFunctionName(new errorLike()); // eslint-disable-line new-cap
   }
 
   return constructorName;

--- a/test/index.js
+++ b/test/index.js
@@ -85,8 +85,22 @@ describe('checkError', function () {
       return 1;
     }
 
+    var anonymousFunc = function () { // eslint-disable-line func-style
+      return 2;
+    };
+
+    // See chaijs/chai/issues/45: some poorly-constructed custom errors don't have useful names
+    // on either their constructor or their constructor prototype, but instead
+    // only set the name inside the constructor itself.
+    var PoorlyConstructedError = function () { // eslint-disable-line func-style
+      this.name = 'PoorlyConstructedError'; // eslint-disable-line no-invalid-this
+    };
+    PoorlyConstructedError.prototype = Object.create(Error.prototype);
+
     assert(checkError.getConstructorName(correctName) === 'correctName');
     assert(checkError.getConstructorName(withoutComments) === 'withoutComments');
+    assert(checkError.getConstructorName(anonymousFunc) === '');
+    assert(checkError.getConstructorName(PoorlyConstructedError) === 'PoorlyConstructedError');
   });
 
   it('getMessage', function () {


### PR DESCRIPTION
Hello everyone,

Do you guys remember about [this comment right here](https://github.com/chaijs/check-error/pull/4#issuecomment-223279797)? Turns out I was wrong.

I have forgotten about why I needed `new` there.
Actually we do needed the `new` keyword there because of poorly-constructed errors like the ones described in [this issue](https://github.com/chaijs/chai/issues/45).

I found this out when updating [this PR on Chai](https://github.com/chaijs/chai/pull/683).

The only fix which could be done is to check if we've got an empty name for `errorLike` and then try to run it again with a `new` instance of it.

I have also added new tests to prove this behavior and also tests to cover anonymous functions.

Thanks for your attention guys 😄 