### PR TITLE
fix: tests for anonymous functions on IE

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,8 @@ function getConstructorName(errorLike) {
     // If `err` is not an instance of Error it is an error constructor itself or another function.
     // If we've got a common function we get its name, otherwise we may need to create a new instance
     // of the error just in case it's a poorly-constructed error. Please see chaijs/chai/issues/45 to know more.
-    constructorName = getFunctionName(errorLike) || getFunctionName(new errorLike()); // eslint-disable-line new-cap
+    constructorName = getFunctionName(errorLike).trim() ||
+        getFunctionName(new errorLike()); // eslint-disable-line new-cap
   }
 
   return constructorName;


### PR DESCRIPTION
This fixes tests for IE9 and above.
The problem was that IE was returning `' '` for anonymous functions and therefore it didn't match `''`.
This also fixes errors regarding poorly-constructed errors, because `' '` would not evaluate to `false` and therefore we couldn't do `getConstructorName(new errorLike())` and this would fail too.

Here we go 🎉 