### PR TITLE
chore(package): tweak repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "./index.js",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/chaijs/check-error.git"
+    "url": "git@github.com:chaijs/check-error.git"
   },
   "scripts": {
     "build": "browserify --bare $npm_package_main --standalone checkError -o check-error.js",


### PR DESCRIPTION
Release docs aren't being generated (see https://travis-ci.org/chaijs/check-error/jobs/135713148#L575-L600). I have a feeling it might be because of this URL. This PR just changes the URL to the same format as the one deep-eql has, hopefully the next release docs will be auto generated from now on 😄 