### PR TITLE
fix: anonymous functions on node 6.5 and above

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -85,9 +85,11 @@ describe('checkError', function () {
       return 1;
     }
 
-    var anonymousFunc = function () { // eslint-disable-line func-style
-      return 2;
-    };
+    var anonymousFunc = (function () {
+      return function () { // eslint-disable-line func-style
+        return 2;
+      };
+    }());
 
     // See chaijs/chai/issues/45: some poorly-constructed custom errors don't have useful names
     // on either their constructor or their constructor prototype, but instead


### PR DESCRIPTION
This fixes tests for Node versions above 6.5, in which the anonymous functions receive the name of the variable they're assigned to.