### PR TITLE
External get func name

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
  * MIT Licensed
  */
 
+var getFunctionName = require('get-func-name');
 /**
  * ### .checkError
  *
@@ -86,36 +87,6 @@ function compatibleMessage(thrown, errMatcher) {
 }
 
 /**
- * ### .getFunctionName(constructorFn)
- *
- * Returns the name of a function.
- * This also includes a polyfill function if `constructorFn.name` is not defined.
- *
- * @name getFunctionName
- * @param {Function} constructorFn
- * @namespace Utils
- * @api private
- */
-
-var toString = Function.prototype.toString;
-var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\s\(\/]+)/;
-function getFunctionName(constructorFn) {
-  var name = '';
-  if (typeof Function.prototype.name === 'undefined' && typeof constructorFn.name === 'undefined') {
-    // Here we run a polyfill if Function does not support the `name` property and if constructorFn.name is not defined
-    var match = toString.call(constructorFn).match(functionNameMatch);
-    if (match) {
-      name = match[1];
-    }
-  } else {
-    // If we've got a `name` property we just use it
-    name = constructorFn.name;
-  }
-
-  return name;
-}
-
-/**
  * ### .getConstructorName(errorLike)
  *
  * Gets the constructor name for an Error instance or constructor itself.
@@ -137,7 +108,7 @@ function getConstructorName(errorLike) {
     constructorName = getFunctionName(errorLike);
     if (constructorName === '') {
       var newConstructorName = getFunctionName(new errorLike()); // eslint-disable-line new-cap
-      constructorName = newConstructorName ? newConstructorName : constructorName;
+      constructorName = newConstructorName || constructorName;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
       "max-statements": 0
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "get-func-name": "^1.0.0"
+  },
   "devDependencies": {
     "browserify": "^13.0.0",
     "browserify-istanbul": "^1.0.0",


### PR DESCRIPTION
This includes a small refactor for this module to use the external `get-func-name` module.
Please notice that this has been made on top of #11.